### PR TITLE
add support for resin websocket

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -213,6 +213,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.caucho</groupId>
+            <artifactId>resin</artifactId>
+            <version>4.0.46</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.atmosphere</groupId>
             <artifactId>atmosphere-compat-jbossweb</artifactId>
             <version>${compat-version}</version>

--- a/modules/cpr/src/main/java/org/atmosphere/container/ResinServlet30AsyncSupportWithWebSocket.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/ResinServlet30AsyncSupportWithWebSocket.java
@@ -1,0 +1,37 @@
+package org.atmosphere.container;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.atmosphere.cpr.Action;
+import org.atmosphere.cpr.AtmosphereConfig;
+import org.atmosphere.cpr.AtmosphereRequest;
+import org.atmosphere.cpr.AtmosphereResponse;
+import org.atmosphere.cpr.WebSocketProcessorFactory;
+import org.atmosphere.websocket.WebSocketProcessor;
+
+public class ResinServlet30AsyncSupportWithWebSocket extends Servlet30CometSupport {
+    public ResinServlet30AsyncSupportWithWebSocket(final AtmosphereConfig config) {
+        super(config);
+    }
+
+    @Override
+    public Action service(final AtmosphereRequest req, final AtmosphereResponse res) throws IOException, ServletException {
+        final WebSocketProcessor webSocketProcessor = WebSocketProcessorFactory.getDefault().getWebSocketProcessor(config.framework());
+        final ResinWebSocketHandler webSocketHandler = ResinWebSocketUtil.getHandler(req, config, webSocketProcessor);
+        final Action action = ResinWebSocketUtil.doService(this, req, res, webSocketHandler);
+
+        return action == null ? super.service(req, res) : action;
+    }
+
+    @Override
+    public String getContainerName() {
+        return config.getServletConfig().getServletContext().getServerInfo() + " with WebSocket enabled.";
+    }
+
+    @Override
+    public boolean supportWebSocket() {
+        return true;
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/container/ResinWebSocketHandler.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/ResinWebSocketHandler.java
@@ -1,10 +1,11 @@
-package jp.co.intra_mart.system.atmosphere.container;
+package org.atmosphere.container;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.atmosphere.container.version.ResinWebSocket;
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResponseImpl;
@@ -15,8 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import com.caucho.websocket.WebSocketContext;
 import com.caucho.websocket.WebSocketListener;
-
-import jp.co.intra_mart.system.atmosphere.container.version.ResinWebSocket;
 
 public class ResinWebSocketHandler implements WebSocketListener {
     private static final Logger logger = LoggerFactory.getLogger(ResinWebSocketHandler.class);

--- a/modules/cpr/src/main/java/org/atmosphere/container/ResinWebSocketHandler.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/ResinWebSocketHandler.java
@@ -1,0 +1,97 @@
+package jp.co.intra_mart.system.atmosphere.container;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.atmosphere.cpr.AtmosphereFramework;
+import org.atmosphere.cpr.AtmosphereRequest;
+import org.atmosphere.cpr.AtmosphereResponseImpl;
+import org.atmosphere.websocket.WebSocket;
+import org.atmosphere.websocket.WebSocketProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.caucho.websocket.WebSocketContext;
+import com.caucho.websocket.WebSocketListener;
+
+import jp.co.intra_mart.system.atmosphere.container.version.ResinWebSocket;
+
+public class ResinWebSocketHandler implements WebSocketListener {
+    private static final Logger logger = LoggerFactory.getLogger(ResinWebSocketHandler.class);
+
+    private final AtmosphereRequest request;
+
+    private final AtmosphereFramework framework;
+
+    private final WebSocketProcessor webSocketProcessor;
+
+    private WebSocket webSocket;
+
+    private AtomicBoolean isOpen = new AtomicBoolean();
+
+    public ResinWebSocketHandler(final AtmosphereRequest request, final AtmosphereFramework framework, final WebSocketProcessor webSocketProcessor) {
+        this.request = request;
+        this.framework = framework;
+        this.webSocketProcessor = webSocketProcessor;
+    }
+
+    @Override
+    public void onClose(final WebSocketContext context) throws IOException {
+        logger.debug("onClose");
+
+        try {
+            webSocketProcessor.close(webSocket, 1005);
+            isOpen.set(false);
+        } finally {
+            request.destroy();
+        }
+    }
+
+    @Override
+    public void onDisconnect(final WebSocketContext context) throws IOException {
+        logger.debug("onDisconnect");
+
+        isOpen.set(false);
+    }
+
+    @Override
+    public void onReadBinary(final WebSocketContext context, final InputStream is) throws IOException {
+        logger.debug("onReadBinary");
+
+        webSocketProcessor.invokeWebSocketProtocol(webSocket, is);
+    }
+
+    @Override
+    public void onReadText(final WebSocketContext context, final Reader reader) throws IOException {
+        logger.debug("onReadText");
+
+        webSocketProcessor.invokeWebSocketProtocol(webSocket, reader);
+    }
+
+    @Override
+    public void onStart(final WebSocketContext context) throws IOException {
+        logger.debug("onStart");
+
+        try {
+            isOpen.set(true);
+
+            webSocket = new ResinWebSocket(this, context, framework.getAtmosphereConfig());
+            webSocketProcessor.open(webSocket, request, AtmosphereResponseImpl.newInstance(framework.getAtmosphereConfig(), request, webSocket));
+        } catch (final Exception e) {
+            logger.warn("Failed to connect to WebSocket", e);
+        }
+    }
+
+    @Override
+    public void onTimeout(final WebSocketContext context) throws IOException {
+        logger.debug("onTimeout");
+
+        isOpen.set(false);
+    }
+
+    public boolean isOpen() {
+        return isOpen.get();
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/container/ResinWebSocketUtil.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/ResinWebSocketUtil.java
@@ -1,0 +1,108 @@
+package org.atmosphere.container;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.atmosphere.cpr.Action;
+import org.atmosphere.cpr.ApplicationConfig;
+import org.atmosphere.cpr.AsynchronousProcessor;
+import org.atmosphere.cpr.AtmosphereConfig;
+import org.atmosphere.cpr.AtmosphereRequest;
+import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.AtmosphereResponse;
+import org.atmosphere.util.Utils;
+import org.atmosphere.websocket.WebSocket;
+import org.atmosphere.websocket.WebSocketProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.caucho.websocket.WebSocketServletRequest;
+
+public class ResinWebSocketUtil {
+    private static final Logger logger = LoggerFactory.getLogger(ResinWebSocketUtil.class);
+
+    protected static WebSocketServletRequest getWebSocketServletRequest(final ServletRequest request) {
+        if (request instanceof WebSocketServletRequest) {
+            return (WebSocketServletRequest) request;
+        }
+
+        ServletRequest wrapped = request;
+
+        while (wrapped instanceof HttpServletRequestWrapper) {
+            wrapped = ((HttpServletRequestWrapper) wrapped).getRequest();
+
+            if (wrapped instanceof WebSocketServletRequest) {
+                return (WebSocketServletRequest) wrapped;
+            }
+        }
+
+        return null;
+    }
+
+    public final static Action doService(final AsynchronousProcessor cometSupport, final AtmosphereRequest req, final AtmosphereResponse res, final ResinWebSocketHandler webSocketHandler) throws IOException, ServletException {
+        Boolean b = (Boolean) req.getAttribute(WebSocket.WEBSOCKET_INITIATED);
+        if (b == null) {
+            b = Boolean.FALSE;
+        }
+
+        if (!Utils.webSocketEnabled(req) && req.getAttribute(WebSocket.WEBSOCKET_ACCEPT_DONE) == null) {
+            if (req.resource() != null && req.resource().transport() == AtmosphereResource.TRANSPORT.WEBSOCKET) {
+                WebSocket.notSupported(req, res);
+                return Action.CANCELLED;
+            } else {
+                return null;
+            }
+        } else {
+            if (webSocketHandler != null && !b) {
+                req.setAttribute(WebSocket.WEBSOCKET_INITIATED, true);
+                try {
+                    final HttpServletRequest wrappedRequest = req.wrappedRequest();
+                    final WebSocketServletRequest webSocketServletRequest = getWebSocketServletRequest(wrappedRequest);
+                    if (webSocketServletRequest != null) {
+                        webSocketServletRequest.startWebSocket(webSocketHandler);
+                    }
+                } catch (final IllegalStateException ex) {
+                    logger.trace("", ex);
+                    WebSocket.notSupported(req, res);
+                    return Action.CANCELLED;
+                }
+                req.setAttribute(WebSocket.WEBSOCKET_ACCEPT_DONE, true);
+                return new Action();
+            }
+
+            final Action action = cometSupport.suspended(req, res);
+            if (action.type() == Action.TYPE.SUSPEND) {
+            } else if (action.type() == Action.TYPE.RESUME) {
+                req.setAttribute(WebSocket.WEBSOCKET_RESUME, true);
+            }
+
+            return action;
+        }
+    }
+
+    public final static ResinWebSocketHandler getHandler(final AtmosphereRequest req, final AtmosphereConfig config, final WebSocketProcessor webSocketProcessor) {
+        final AtomicBoolean useBuildInSession = new AtomicBoolean(config.isSupportSession());
+
+        {
+            final String s = config.getInitParameter(ApplicationConfig.BUILT_IN_SESSION);
+
+            if (s != null) {
+                useBuildInSession.set(Boolean.valueOf(s));
+            }
+        }
+
+        final HttpServletRequest wrapped = req.wrappedRequest();
+
+        if (!webSocketProcessor.handshake(wrapped)) {
+            // res.sendError(HttpServletResponse.SC_FORBIDDEN, "WebSocket requests rejected.");
+            throw new IllegalStateException();
+        }
+
+        return new ResinWebSocketHandler(req, config.framework(), webSocketProcessor);
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/container/version/ResinWebSocket.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/version/ResinWebSocket.java
@@ -1,0 +1,73 @@
+package org.atmosphere.container.version;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+import org.atmosphere.container.ResinWebSocketHandler;
+import org.atmosphere.cpr.AtmosphereConfig;
+import org.atmosphere.cpr.AtmosphereResponse;
+import org.atmosphere.websocket.WebSocket;
+
+import com.caucho.websocket.WebSocketContext;
+
+public class ResinWebSocket extends WebSocket {
+    private final ResinWebSocketHandler handler;
+
+    private final WebSocketContext context;
+
+    public ResinWebSocket(final ResinWebSocketHandler handler, final WebSocketContext context, final AtmosphereConfig config) {
+        super(config);
+
+        this.handler = handler;
+        this.context = context;
+    }
+
+    @Override
+    public String toString() {
+        return context.toString();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return handler.isOpen();
+    }
+
+    @Override
+    public WebSocket write(final String s) throws IOException {
+        logger.trace("WebSocket.write() for {}", resource() != null ? resource().uuid() : "");
+
+        try (PrintWriter writer = context.startTextMessage()) {
+            writer.print(s);
+        }
+
+        return this;
+    }
+
+    @Override
+    public WebSocket write(final byte[] b, final int offset, final int length) throws IOException {
+        logger.trace("WebSocket.write() for {}", resource() != null ? resource().uuid() : "");
+
+        try (OutputStream ostr = context.startBinaryMessage()) {
+            ostr.write(b, offset, length);
+        }
+
+        return this;
+    }
+
+    @Override
+    public void close() {
+        logger.trace("WebSocket.close() for AtmosphereResource {}", resource() != null ? resource().uuid() : "null");
+
+        context.close();
+    }
+
+    @Override
+    public WebSocket flush(final AtmosphereResponse r) throws IOException {
+        logger.trace("WebSocket.flush() for {}", r.uuid());
+
+        context.flush();
+
+        return this;
+    }
+}


### PR DESCRIPTION
Resin doesn't support JSR 356 and have custom websocket implementation.
http://caucho.com/resin-4.0/admin/websocket.xtp

This PR add support for the above implementation.

To support websocket for resin, add the following configuration to web.xml
<pre>
        &lt;init-param&gt;
            &lt;param-name&gt;org.atmosphere.cpr.asyncSupport&lt;/param-name&gt;
            &lt;param-value&gt;org.atmosphere.container.ResinServlet30AsyncSupportWithWebSocket&lt;/param-value&gt;
        &lt;/init-param&gt;
</pre>